### PR TITLE
Add Makefile To Build With Oct 2020 Emscripten

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,8 @@
 # Building
 
 ```sh
-$ cd ext
-$ git clone https://github.com/libigl/eigen.git
-$ cd ..
-$ em++ -DNANOVG_GLES3_IMPLEMENTATION -DGLFW_INCLUDE_ES3 -DGLFW_INCLUDE_GLEXT -DNANOGUI_LINUX -Iext/nanovg/ ext/nanovg.c --std=c++11 -O3 -lGL -lGLU -lm -lGLEW -s USE_GLFW=3 -s FULL_ES3=1 -s USE_WEBGL2=1 -o nanovg.bc
-$ em++ -DNANOVG_GLES3_IMPLEMENTATION -DGLFW_INCLUDE_ES3 -DGLFW_INCLUDE_GLEXT -DNANOGUI_LINUX -Iinclude/ -Iext/nanovg/ -Iext/eigen/ button.cpp checkbox.cpp colorpicker.cpp colorwheel.cpp combobox.cpp common.cpp glcanvas.cpp glutil.cpp graph.cpp imagepanel.cpp imageview.cpp label.cpp layout.cpp messagedialog.cpp popup.cpp popupbutton.cpp progressbar.cpp screen.cpp serializer.cpp slider.cpp stackedwidget.cpp tabheader.cpp tabwidget.cpp textbox.cpp theme.cpp vscrollpanel.cpp widget.cpp window.cpp nanogui_resources.cpp nanovg.bc --std=c++11 -O3 -lGL -lGLU -lm -lGLEW -s USE_GLFW=3 -s FULL_ES3=1 -s USE_WEBGL2=1 -s WASM=1 -o nanogui.bc
-$ mkdir build
-$ em++ -DNANOVG_GLES3_IMPLEMENTATION -DGLFW_INCLUDE_ES3 -DGLFW_INCLUDE_GLEXT -DNANOGUI_LINUX -Iinclude/ -Iext/nanovg/ -Iext/eigen/ nanogui.bc example1.cpp --std=c++11 -O3 -lGL -lGLU -lm -lGLEW -s USE_GLFW=3 -s FULL_ES3=1 -s USE_WEBGL2=1 -s WASM=1 -o build/nanogui.html --preload-file ./icons
+$ git clone https://github.com/libigl/eigen.git ext/eigen
+$ make
 ```
 
 **Problems**

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,1 @@
+This is where the makefile puts `nanogui.html` and the WASM build products.

--- a/makefile
+++ b/makefile
@@ -1,0 +1,28 @@
+# Very quick/dirty makefile for building the nanogui example1.cpp in emscripten
+# Puts the result in the `build/` directory
+#
+# Makefile tips:
+#
+#   * GNU make wants tab indentation, will error on spaces
+#   * `$@` means substitute the target
+#   * `$<` means substitute first thing in dependency list
+#   * `$^` means substitute everything in the dependency list
+
+CC=em++
+
+NANOFLAGS=-DNANOGUI_LINUX -DNANOVG_GLES3_IMPLEMENTATION
+GLFLAGS=-DGLFW_INCLUDE_ES3 -DGLFW_INCLUDE_GLEXT -s USE_GLFW=3 -s FULL_ES3=1 -s USE_WEBGL2=1 
+EMFLAGS=--std=c++11 -O3 -s WASM=1
+INCFLAGS=-Iinclude/ -Iext/nanovg/ -Iext/eigen/
+LDFLAGS=-lGL -lm -lGLEW
+
+CFLAGS=$(INCFLAGS) $(EMFLAGS) $(NANOFLAGS) $(GLFLAGS)
+
+build/nanogui.html: nanovg.wasm button.wasm checkbox.wasm colorpicker.wasm colorwheel.wasm combobox.wasm common.wasm glcanvas.wasm glutil.wasm graph.wasm imagepanel.wasm imageview.wasm label.wasm layout.wasm messagedialog.wasm popup.wasm popupbutton.wasm progressbar.wasm screen.wasm serializer.wasm slider.wasm stackedwidget.wasm tabheader.wasm tabwidget.wasm textbox.wasm theme.wasm vscrollpanel.wasm widget.wasm window.wasm nanogui_resources.wasm
+	$(CC) $(CFLAGS) example1.cpp $^ $(LDFLAGS) -o $@ --preload-file ./icons
+
+nanovg.wasm: ext/nanovg.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+%.wasm: %.cpp
+	$(CC) $(CFLAGS) -c $< -o $@


### PR DESCRIPTION
The previous build instructions would not work under the current
Emscripten.  They have moved away from offering LLVM BitCode as
a target (at least, there's no obvious way to get it).

If the `-c` option is used, then the generated .wasm file will be
relocatable and can act as an object file would.  However, this
does not allow the combining of multiple source files into a single
bitcode file in the way the instructions previously had.

Also: the -lGLU option does not seem to work in this version.  The
removal of the switch resulted in a successful link and run of the
built product.

This commit is an offering of the makefile which I used to build.
Doing better would involve putting the intermediate .wasm files in
their own directories etc.  But this was just to get it built for
a quick test, so improvements are left as an exercise to the
reader.  :-)